### PR TITLE
Make naming scheme more generic

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,11 @@
+coverage:
+  status:
+    project:
+      default:
+        enabled: yes
+        target: 80%
+    patch:
+      default:
+        enabled: yes
+        target: 80%
 comment: false

--- a/src/NetworkInference.jl
+++ b/src/NetworkInference.jl
@@ -4,10 +4,10 @@ using InformationMeasures
 using Distributions
 
 export
-    # Common types and functions
-    Gene,
+    # Common types
+    Node,
     Edge,
-    NetworkAnalysis,
+    InferredNetwork,
     # Network inference algorithms
     AbstractNetworkInference,
     MINetworkInference,
@@ -15,7 +15,7 @@ export
     PUCNetworkInference,
     PIDCNetworkInference,
     # Functions for inferring networks
-    get_genes,
+    get_nodes,
     write_network_file,
     get_edge_list,
     infer_network

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,32 +1,53 @@
-immutable Gene
-    name::String
-    discretized_values::Array{Int64}
+# Basic types for inferring a network
+
+# Node type with metadata:
+# - label: unique identifying label
+# - binned_values: data values discretized into bins
+# - number_of_bins: no. bins the data were discretized into
+# - probabilities: probability distribution across the bins
+struct Node
+    label::String
+    binned_values::Array{Int64}
     number_of_bins::Int64
     probabilities::Array{Float64}
 end
 
-# Make a Gene from a data file line
-# discretzed_values is expression_values mapped to bin ids, following discretization
-function Gene(line::AbstractArray, discretizer, estimator, number_of_bins)
+# Constructs a Node from a line of a data file. line should be an array with
+# the label as the first element, then the raw data values.
+function Node(line::AbstractArray, discretizer, estimator, number_of_bins)
 
-    name = string(line[1])
-    expression_values = Array{Float64}(line[2:end])
-    discretized_values = zeros(Int, length(expression_values))
-    # If discretizer is Bayesian blocks, number_of_bins will be overwritten
-    number_of_bins = get_bin_ids!(expression_values, discretizer, number_of_bins, discretized_values)
-    probabilities = get_probabilities(estimator, get_frequencies_from_bin_ids(discretized_values, number_of_bins))
+    label = string(line[1])
+    raw_values = Array{Float64}(line[2:end])
 
-    return Gene(name, discretized_values, number_of_bins, probabilities)
+    # Raw values are mapped to their bin IDs
+    binned_values = zeros(Int, length(raw_values))
+
+    # If the discretizer is Bayesian blocks, number_of_bins will be
+    # overwritten by the ideal number of bins. Otherwise, it will remain
+    # the same as the value passed in.
+    number_of_bins = get_bin_ids!(raw_values, discretizer, number_of_bins, binned_values)
+
+    probabilities = get_probabilities(estimator, get_frequencies_from_bin_ids(binned_values, number_of_bins))
+
+    return Node(label, binned_values, number_of_bins, probabilities)
 
 end
 
-immutable GenePair
-    mi::Float64 # Mutual information
-    si::Array{Float64} # Specific information
+# Type for caching information between pairs of nodes:
+# - mi: mutual information
+# - si: specific information
+struct NodePair
+    mi::Float64
+    si::Array{Float64}
 end
 
-# Networks are assumed to be undirected for now: order of the genes is arbitrary
-immutable Edge
-    genes::Array{Gene}
-    confidence::Float64
+# Edge type, undirected:
+# - nodes: the two nodes, in an arbitrary order
+# - weight: weight indicating confidence of edge existing in the true network
+# Weights are used to rank the edges, and different algorithms may have a
+# different scale. The relative weights within one inferred network are
+# therefore more meaningful than the absolute weight out of context.
+struct Edge
+    nodes::Array{Node}
+    weight::Float64
 end

--- a/src/infer_network.jl
+++ b/src/infer_network.jl
@@ -1,39 +1,55 @@
-# The maximum likelihood estimator is recommended for PUC and PIDC, because speedups
-# are made here, based on the assumption that the marginal probability distribution for
-# a gene, from the joint distribution with any two other genes is always the same. If
-# the joint distributions are estimated using other estimators, this assumption is
-# violated for PUC and PIDC in get_puc and get_joint_probabilities.
-function get_genes(data_file_path::String; delim::Union{Char,Bool} = false, discretizer = "bayesian_blocks",
+# Helper functions for inferring a network from a data file
+
+# Gets an array of all Nodes from a data file. It is assumed that the first
+# line of the file is headers (which are discarded) and the subsequent lines
+# each represent one node, and are of the form:
+# Label    data_value1  data_value2 ...
+# although a different delimiter may be specified.
+#
+# Keyword arguments:
+# - delim: the file's delimiter. Leave as false if it is whitespace
+# - discretizer: algorithm for discretizing the data
+# - estimator: algorithm for estimating the probability distribution
+#   "maximum_likelihood" is recommended for PUC and PIDC (see InferredNetwork
+#   type for more details)
+# - number_of_bins: will be overwritten if using "bayesian_blocks"
+function get_nodes(data_file_path::String; delim::Union{Char,Bool} = false, discretizer = "bayesian_blocks",
     estimator = "maximum_likelihood", number_of_bins = 10)
 
     if delim == false
-        lines = readdlm(open(data_file_path); skipstart = 1) # Assumes the first line is headers
+        lines = readdlm(open(data_file_path); skipstart = 1)
     else
-        lines = readdlm(open(data_file_path), delim; skipstart = 1) # Assumes the first line is headers
+        lines = readdlm(open(data_file_path), delim; skipstart = 1)
     end
-    number_of_genes = size(lines, 1)
-    genes = Array{Gene}(number_of_genes)
+    number_of_nodes = size(lines, 1)
+    nodes = Array{Node}(number_of_nodes)
 
-    for i in 1:number_of_genes
-        genes[i] = Gene(lines[i:i, 1:end], discretizer, estimator, number_of_bins)
+    for i in 1:number_of_nodes
+        nodes[i] = Node(lines[i:i, 1:end], discretizer, estimator, number_of_bins)
     end
 
-    return genes
+    return nodes
 
 end
 
-# Networks are undirected; edges are written in both directions with the same confidence
-function write_network_file(file_name::String, network_analysis::NetworkAnalysis)
+# Writes a network file from an InferredNetwork type. Each line of the file
+# will contain an edge, and since networks are assumed undirected, each edge
+# will be written in both directions with the same weight:
+# ...
+# LabelX   LabelY  WeightXY
+# LabelY   LabelX  WeightXY
+# ...
+function write_network_file(file_path::String, inferred_network::InferredNetwork)
 
-    out_file = open(file_name, "w")
+    out_file = open(file_path, "w")
 
-    for edge in network_analysis.edges
-        genes = edge.genes
+    for edge in inferred_network.edges
+        nodes = edge.nodes
         write(out_file, string(
-            genes[1].name, "\t", genes[2].name, "\t",
-            edge.confidence, "\n",
-            genes[2].name, "\t", genes[1].name, "\t",
-            edge.confidence, "\n"
+            nodes[1].label, "\t", nodes[2].label, "\t",
+            edge.weight, "\n",
+            nodes[2].label, "\t", nodes[1].label, "\t",
+            edge.weight, "\n"
         ))
     end
 
@@ -41,24 +57,41 @@ function write_network_file(file_name::String, network_analysis::NetworkAnalysis
 
 end
 
-# Networks are undirected; edges are only listed in one direction
-function get_edge_list(network_analysis::NetworkAnalysis)
+# Gets an edge list array from an InferredNetwork object.
+function get_edge_list(inferred_network::InferredNetwork)
     edge_list = Tuple{String,String,Float64}[]
 
-    for edge in network_analysis.edges
-        genes = edge.genes
-        push!(edge_list, (genes[1].name, genes[2].name, edge.confidence))
+    for edge in inferred_network.edges
+        nodes = edge.nodes
+        push!(edge_list, (nodes[1].label, nodes[2].label, edge.weight))
     end
 
     return edge_list
 end
 
+# Infers a network, given a data file and a network inference algorithm. It
+# is assumed that the first line of the file is headers (which are
+# discarded) and the subsequent lines each represent one node, and are of
+# the form:
+# Label    data_value1  data_value2 ...
+# although a different delimiter may be specified.
+#
+# Keyword arguments:
+# - delim: the file's delimiter. Leave as false if it is whitespace
+# - discretizer: algorithm for discretizing the data
+# - estimator: algorithm for estimating the probability distribution
+#   "maximum_likelihood" is recommended for PUC and PIDC (see InferredNetwork
+#   type for more details)
+# - number_of_bins: will be overwritten if using "bayesian_blocks"
+# - base: base for the information measures
+# - out_file_path: path to output file. If left as empty string, no file will
+# be written.
 function infer_network(data_file_path::String, inference::AbstractNetworkInference; delim::Union{Char,Bool} = false,
     discretizer = "bayesian_blocks", estimator = "maximum_likelihood", number_of_bins = 10, base = 2,
-    out_file = "")
+    out_file_path = "")
 
-    println("Getting genes...")
-    genes = get_genes(
+    println("Getting nodes...")
+    nodes = get_nodes(
         data_file_path,
         delim = delim,
         discretizer = discretizer,
@@ -67,14 +100,13 @@ function infer_network(data_file_path::String, inference::AbstractNetworkInferen
     )
 
     println("Inferring network...")
-    network_analysis = NetworkAnalysis(inference, genes, estimator = estimator, base = base)
+    inferred_network = InferredNetwork(inference, nodes, estimator = estimator, base = base)
 
-    if length(out_file) > 1
+    if length(out_file_path) > 1
         println("Writing network to file...")
-        write_network_file(out_file, network_analysis)
+        write_network_file(out_file_path, inferred_network)
     end
 
-    println("Getting edge list...")
-    return get_edge_list(network_analysis)
+    return inferred_network
 
 end

--- a/src/network_inference.jl
+++ b/src/network_inference.jl
@@ -1,9 +1,13 @@
-abstract type AbstractNetworkInference end
+# Network inference algorithms and the InferredNetwork type. The algorithms MI, CLR, PUC and
+# PIDC are explained in http://biorxiv.org/content/early/2017/04/26/082099 - along with terms
+# such as specific information, proportional unique contribution, context, etc.
 
-immutable MINetworkInference <: AbstractNetworkInference end
-immutable CLRNetworkInference <: AbstractNetworkInference end
-immutable PUCNetworkInference <: AbstractNetworkInference end
-immutable PIDCNetworkInference <: AbstractNetworkInference end
+# Network inference algorithms
+abstract type AbstractNetworkInference end
+struct MINetworkInference <: AbstractNetworkInference end
+struct CLRNetworkInference <: AbstractNetworkInference end
+struct PUCNetworkInference <: AbstractNetworkInference end
+struct PIDCNetworkInference <: AbstractNetworkInference end
 
 # Context trait
 apply_context(::MINetworkInference) = false
@@ -18,23 +22,24 @@ get_puc(::PUCNetworkInference) = true
 get_puc(::PIDCNetworkInference) = true
 
 # For sorting the edges
-get_confidence(edge::Edge) = edge.confidence
+get_weight(edge::Edge) = edge.weight
 
-function get_joint_probabilities(gene1, gene2, estimator)
+# Gets the joint probability distribution for two Nodes.
+function get_joint_probabilities(node1, node2, estimator)
 
     frequencies = get_frequencies_from_bin_ids(
-        gene1.discretized_values,
-        gene2.discretized_values,
-        gene1.number_of_bins,
-        gene2.number_of_bins
+        node1.binned_values,
+        node2.binned_values,
+        node1.number_of_bins,
+        node2.number_of_bins
     )
 
     probabilities = get_probabilities(estimator, frequencies)
-    # probabilities is already property of a gene, but doing this gets correct array shapes.
+    # probabilities is already property of a node, but doing this gets correct array shapes.
     # Also, for MI and CLR, it means that we don't assume that the marginal probabilities for
-    # a gene are always the same, no matter what the second gene is, meaning that we can use
+    # a node are always the same, no matter what the second node is, meaning that we can use
     # estimators other than maximum likelihood. (We still can't do this for PUC and PIDC,
-    # because we do make that assumption for 3-gene joint distributions, in get_puc.)
+    # because we do make that assumption for 3-node joint distributions, in get_puc.)
     probabilities1 = sum(probabilities, 2)
     probabilities2 = sum(probabilities, 1)
 
@@ -42,20 +47,21 @@ function get_joint_probabilities(gene1, gene2, estimator)
 
 end
 
-function get_mi_scores(genes, number_of_genes, estimator, base)
+# Gets the mutual information between all pairs of Nodes.
+function get_mi_scores(nodes, number_of_nodes, estimator, base)
 
-    function get_mi(gene1, gene2, i, j, base, mi_scores)
-        probabilities, probabilities1, probabilities2 = get_joint_probabilities(gene1, gene2, estimator)
+    function get_mi(node1, node2, i, j, base, mi_scores)
+        probabilities, probabilities1, probabilities2 = get_joint_probabilities(node1, node2, estimator)
         mi = apply_mutual_information_formula(probabilities, probabilities1, probabilities2, base)
         mi_scores[i, j] = mi
         mi_scores[j, i] = mi
     end
 
-    mi_scores = SharedArray{Float64}(number_of_genes, number_of_genes)
+    mi_scores = SharedArray{Float64}(number_of_nodes, number_of_nodes)
 
-    @sync @parallel for i in 1 : number_of_genes
-        for j in i+1 : number_of_genes
-            get_mi(genes[i], genes[j], i, j, base, mi_scores)
+    @sync @parallel for i in 1 : number_of_nodes
+        for j in i+1 : number_of_nodes
+            get_mi(nodes[i], nodes[j], i, j, base, mi_scores)
         end
     end
 
@@ -63,20 +69,21 @@ function get_mi_scores(genes, number_of_genes, estimator, base)
 
 end
 
-function get_puc_scores(genes, number_of_genes, estimator, base)
+# Gets the proportional unique contribution between all pairs of Nodes.
+function get_puc_scores(nodes, number_of_nodes, estimator, base)
 
-    function get_mi_and_si(gene1, gene2, base) # Mutual information and specific information
-        probabilities, probabilities1, probabilities2 = get_joint_probabilities(gene1, gene2, estimator)
+    function get_mi_and_si(node1, node2, base) # Mutual information and specific information
+        probabilities, probabilities1, probabilities2 = get_joint_probabilities(node1, node2, estimator)
         mi = apply_mutual_information_formula(probabilities, probabilities1, probabilities2, base)
         si1 = apply_specific_information_formula(probabilities, probabilities1, probabilities2, 1, base)
         si2 = apply_specific_information_formula(probabilities, probabilities2, probabilities1, 2, base)
         return (mi, si1, si2)
     end
 
-    function get_gene_pairs(gene1, gene2, i, j, base)
-        mi, si1, si2 = get_mi_and_si(gene1, gene2, base)
-        gene_pairs[i, j] = GenePair(mi, si1)
-        gene_pairs[j, i] = GenePair(mi, si2)
+    function get_node_pairs(node1, node2, i, j, base)
+        mi, si1, si2 = get_mi_and_si(node1, node2, base)
+        node_pairs[i, j] = NodePair(mi, si1)
+        node_pairs[j, i] = NodePair(mi, si2)
     end
 
     function increment_puc_scores(x, z, mi, redundancy, puc_scores)
@@ -97,21 +104,21 @@ function get_puc_scores(genes, number_of_genes, estimator, base)
         increment_puc_scores(y, z, source2_target.mi, redundancy, puc_scores)
     end
 
-    gene_pairs = Array{GenePair}(number_of_genes, number_of_genes)
-    puc_scores = SharedArray{Float64}(number_of_genes, number_of_genes)
+    node_pairs = Array{NodePair}(number_of_nodes, number_of_nodes)
+    puc_scores = SharedArray{Float64}(number_of_nodes, number_of_nodes)
 
-    for i in 1 : number_of_genes
-        for j in i+1 : number_of_genes
-            get_gene_pairs(genes[i], genes[j], i, j, base)
+    for i in 1 : number_of_nodes
+        for j in i+1 : number_of_nodes
+            get_node_pairs(nodes[i], nodes[j], i, j, base)
         end
     end
 
-    @sync @parallel for i in 1 : number_of_genes
-        for j in i+1 : number_of_genes
-            for k in j+1 : number_of_genes
-                get_puc(genes[k], gene_pairs[i, k], gene_pairs[j, k], i, j, k, puc_scores)
-                get_puc(genes[j], gene_pairs[i, j], gene_pairs[k, j], i, k, j, puc_scores)
-                get_puc(genes[i], gene_pairs[j, i], gene_pairs[k, i], j, k, i, puc_scores)
+    @sync @parallel for i in 1 : number_of_nodes
+        for j in i+1 : number_of_nodes
+            for k in j+1 : number_of_nodes
+                get_puc(nodes[k], node_pairs[i, k], node_pairs[j, k], i, j, k, puc_scores)
+                get_puc(nodes[j], node_pairs[i, j], node_pairs[k, j], i, k, j, puc_scores)
+                get_puc(nodes[i], node_pairs[j, i], node_pairs[k, i], j, k, i, puc_scores)
             end
         end
     end
@@ -120,96 +127,108 @@ function get_puc_scores(genes, number_of_genes, estimator, base)
 
 end
 
-function get_confidences(inference, scores, number_of_genes, genes)
+# Applies context to the raw edge weights.
+function get_weights(inference, scores, number_of_nodes, nodes)
 
     # In their respective original implementations, CLR and PIDC applied network context in slightly
     # different ways. Those differences are respected here; in informal tests, they have not been
     # found to make much of a difference.
-    function get_confidence(::PIDCNetworkInference, i, j, scores, confidences, genes)
+    function get_weight(::PIDCNetworkInference, i, j, scores, weights, nodes)
         score = scores[i, j]
         scores_i = vcat(scores[1:i-1, i], scores[i+1:end, i])
         scores_j = vcat(scores[1:j-1, j], scores[j+1:end, j])
         try
-            confidences[i, j] = cdf(fit(Gamma, scores_i), score) + cdf(fit(Gamma, scores_j), score)
+            weights[i, j] = cdf(fit(Gamma, scores_i), score) + cdf(fit(Gamma, scores_j), score)
         catch
-            println(string("Gamma distribution failed for ", genes[i].name, " and ", genes[j].name, "; used normal instead."))
-            get_clr_confidence(i, j, score, scores_i, scores_j, confidences)
+            println(string("Gamma distribution failed for ", nodes[i].label, " and ", nodes[j].label, "; used normal instead."))
+            apply_clr_context(i, j, score, scores_i, scores_j, weights)
         end
     end
 
-    function get_confidence(::CLRNetworkInference, i, j, scores, confidences, genes)
+    function get_weight(::CLRNetworkInference, i, j, scores, weights, nodes)
         score = scores[i, j]
         scores_i = vcat(scores[1:i-1, i], scores[i+1:end, i])
         scores_j = vcat(scores[1:j-1, j], scores[j+1:end, j])
-        get_clr_confidence(i, j, score, scores_i, scores_j, confidences)
+        apply_clr_context(i, j, score, scores_i, scores_j, weights)
     end
 
-    function get_clr_confidence(i, j, score, scores_i, scores_j, confidences)
+    function apply_clr_context(i, j, score, scores_i, scores_j, weights)
         difference_i = score - mean(scores_i)
         difference_j = score - mean(scores_j)
-        confidences[i, j] = sqrt(
+        weights[i, j] = sqrt(
             (var(scores_i) == 0 || difference_i < 0 ? 0 : difference_i^2 / var(scores_i)) +
             (var(scores_j) == 0 || difference_j < 0 ? 0 : difference_j^2 / var(scores_j))
         )
     end
 
-    confidences = SharedArray{Float64}(number_of_genes, number_of_genes)
+    weights = SharedArray{Float64}(number_of_nodes, number_of_nodes)
 
-    @sync @parallel for i in 1 : number_of_genes
-        for j in i+1 : number_of_genes
-            get_confidence(inference, i, j, scores, confidences, genes)
+    @sync @parallel for i in 1 : number_of_nodes
+        for j in i+1 : number_of_nodes
+            get_weight(inference, i, j, scores, weights, nodes)
         end
     end
 
-    return confidences
+    return weights
 
 end
 
-immutable NetworkAnalysis
-    genes::Array{Gene}
-    edges::Array{Edge} # All possible edges, in descending order of confidence
+# InferredNetwork type. Represents a weighted, fully connected network, where an
+# edges's weight indicates the relative confidence of that edge existing in the true
+# network.
+# - nodes: array of all the nodes, in an arbitrary order
+# - edges: array of all the edges, in descending order of weight
+struct InferredNetwork
+    nodes::Array{Node}
+    edges::Array{Edge}
 end
 
-# The maximum likelihood estimator is recommended for PUC and PIDC, because speedups
+# Constructs an InferredNetwork given a network inference algorithm and an array of
+# Nodes.
+#
+# Keyword arguments:
+# - estimator: algorithm for estimating the probability distribution
+# (The "maximum_likelihood" estimator is recommended for PUC and PIDC, because speedups
 # are made here, based on the assumption that the marginal probability distribution for
-# a gene, from the joint distribution with any two other genes is always the same. If
+# a node, from the joint distribution with any two other nodes is always the same. If
 # the joint distributions are estimated using other estimators, this assumption is
-# violated for PUC and PIDC in get_puc and get_joint_probabilities.
-function NetworkAnalysis(inference::AbstractNetworkInference, genes::Array{Gene}; estimator = "maximum_likelihood", base = 2)
+# violated for PUC and PIDC in get_puc and get_joint_probabilities.)
+# - base: base for the information measures
+function InferredNetwork(inference::AbstractNetworkInference, nodes::Array{Node}; estimator = "maximum_likelihood", base = 2)
 
     # Constants and containers
-    number_of_genes = length(genes)
-    edges = Array{Edge}(binomial(number_of_genes, 2))
+    number_of_nodes = length(nodes)
+    edges = Array{Edge}(binomial(number_of_nodes, 2))
 
     # Get the raw scores
     if get_puc(inference)
-        scores = get_puc_scores(genes, number_of_genes, estimator, base)
+        scores = get_puc_scores(nodes, number_of_nodes, estimator, base)
     else
-        scores = get_mi_scores(genes, number_of_genes, estimator, base)
+        scores = get_mi_scores(nodes, number_of_nodes, estimator, base)
     end
 
     # Apply context if necessary
     if apply_context(inference)
-        confidences = get_confidences(inference, scores, number_of_genes, genes)
+        weights = get_weights(inference, scores, number_of_nodes, nodes)
     else
-        confidences = scores
+        weights = scores
     end
 
     # Get edges from scores
     index = 0
-    for i in 1 : number_of_genes
-        gene1 = genes[i]
-        for j in i+1 : number_of_genes
+    for i in 1 : number_of_nodes
+        node1 = nodes[i]
+        for j in i+1 : number_of_nodes
             index += 1
-            gene2 = genes[j]
+            node2 = nodes[j]
             edges[index] = Edge(
-                [gene1, gene2],
-                confidences[i, j]
+                [node1, node2],
+                weights[i, j]
             )
         end
     end
-    sort!(edges; by = get_confidence, rev = true)
+    sort!(edges; by = get_weight, rev = true)
 
-    return NetworkAnalysis(genes, edges)
+    return InferredNetwork(nodes, edges)
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,14 +5,14 @@ using Base.Test
 # GeneNetWeaver: In silico benchmark generation and performance profiling of network inference methods.
 # Schaffter T, Marbach D, and Floreano D. Bioinformatics, 27(16):2263-70, 2011.
 
-println("Getting genes...")
-genes = get_genes("data/yeast1_10_data.txt")
+println("Getting nodes...")
+nodes = get_nodes("data/yeast1_10_data.txt")
 
 println("Inferring networks...")
-mi_network = NetworkAnalysis(MINetworkInference(), genes)
-clr_network = NetworkAnalysis(CLRNetworkInference(), genes)
-puc_network = NetworkAnalysis(PUCNetworkInference(), genes)
-pidc_network = NetworkAnalysis(PIDCNetworkInference(), genes)
+mi_network = InferredNetwork(MINetworkInference(), nodes)
+clr_network = InferredNetwork(CLRNetworkInference(), nodes)
+puc_network = InferredNetwork(PUCNetworkInference(), nodes)
+pidc_network = InferredNetwork(PIDCNetworkInference(), nodes)
 
 # The benchmarks were inferred prior to the implementation of this package. MI, PUC and PIDC were
 # inferred using scripts based on InformationMeasures.jl and CLR was inferred using MINET:
@@ -25,12 +25,12 @@ pidc_benchmark = readdlm("data/pidc.txt")
 
 # Compare a few selected edges throughout the inferred network
 for i in (1, 5, 10, 20, 40)
-    @test mi_network.edges[i].confidence ≈ mi_benchmark[2*i, 3] atol = 0.0001
+    @test mi_network.edges[i].weight ≈ mi_benchmark[2*i, 3] atol = 0.0001
     println("MI network inference $i passed")
-    @test clr_network.edges[i].confidence ≈ clr_benchmark[2*i, 3] atol = 0.0001
+    @test clr_network.edges[i].weight ≈ clr_benchmark[2*i, 3] atol = 0.0001
     println("CLR network inference $i passed")
-    @test puc_network.edges[i].confidence ≈ puc_benchmark[2*i, 3] atol = 0.0001
+    @test puc_network.edges[i].weight ≈ puc_benchmark[2*i, 3] atol = 0.0001
     println("PUC network inference $i passed")
-    @test pidc_network.edges[i].confidence ≈ pidc_benchmark[2*i, 3] atol = 0.0001
+    @test pidc_network.edges[i].weight ≈ pidc_benchmark[2*i, 3] atol = 0.0001
     println("PIDC network inference $i passed")
 end


### PR DESCRIPTION
Avoid the use of specifically biological terms. Also improve on
some of the more ambiguous names. This involves quite a few API
changes:

Gene -> Node
Gene.name -> Node.label
Gene.discretized_values -> Node.binned_values
Edge.genes -> Edge.nodes
Edge.confidence -> Edge.weight
NetworkAnalysis -> InferredNetwork
NetworkAnalysis.genes -> InferredNetwork.edges
get_genes -> get_nodes

infer_network
* now returns an InferredNetwork
* keyword argument out_file is now out_file_path