### PR TITLE
Added no-priors empirical_bayes function + tests

### DIFF
--- a/src/empirical_bayes_glue.jl
+++ b/src/empirical_bayes_glue.jl
@@ -94,7 +94,7 @@ function empirical_bayes(network::InferredNetwork, priors::Dict, num_bins, propo
 
   eb_edges = Array{Edge}(length(edge_list))
 
-  posteriors = empirical_bayes(test_statistics, prior_list, num_bins, proportion_to_keep)
+  posteriors = empirical_bayes(test_statistics, prior_list, num_bins, proportion_to_keep = proportion_to_keep)
 
   for i in 1:length(edge_list)
     nodes = edge_list[i].nodes
@@ -104,6 +104,23 @@ function empirical_bayes(network::InferredNetwork, priors::Dict, num_bins, propo
   sort!(eb_edges, rev = true, by = x->x.weight)
 
   return InferredNetwork(network.nodes, eb_edges)
+end
+
+"""
+  empirical_bayes(network::InferredNetwork, key_func = to_index, num_bins, proportion_to_keep = 1.0)
+
+Calculate the empirical Bayes posteriors of the input statistics with no priors.
+
+# Arguments
+- `network::InferredNetwork` : network to apply priors to.
+- `num_bins` : number of uniform width bins to discretize into.
+- `proportion_to_keep = 1.0` : Proportion of lowest test statistics to
+   keep when calculating null distribution.
+- `key_func = to_index` : a function mapping an Edge object to a key useable in
+   the `priors` dictionary
+"""
+function empirical_bayes(network::InferredNetwork, num_bins, proportion_to_keep = 1.0, key_func = to_index)
+  return empirical_bayes(network, Dict(), num_bins, proportion_to_keep, key_func)
 end
 
 end

--- a/test/empirical_bayes_glue_tests.jl
+++ b/test/empirical_bayes_glue_tests.jl
@@ -31,7 +31,7 @@ reference_priors = Dict( [ (("bbb", "aaa"), 1) ,
 @test make_priors(prior_path) == reference_priors
 
 # Test the empirical_bayes function
-println("inferring test empirical bayes network...")
+println("inferring test empirical bayes networks...")
 mi_benchmark = readdlm(joinpath(data_folder_path, "mi.txt"))
 mi_benchmark = mi_benchmark[1:2:end, :] # skip repeated edges
 
@@ -52,6 +52,15 @@ benchmark_priors = convert(Array{Float64}, mi_priors[:, 3])
 ref_weights = empirical_bayes(benchmark_stats, benchmark_priors, 5)
 
 @test eb_weights ≈ sort(ref_weights, rev = true) atol = 0.0001
+
+# Test the empirical_bayes function with no priors
+println("inferring test empirical bayes networks with no priors...")
+eb_no_prior_network = empirical_bayes(mi_network, 5)
+eb_no_prior_weights = [e.weight for e in eb_no_prior_network.edges]
+
+ref_no_prior_weights = empirical_bayes(benchmark_stats, 5)
+
+@test eb_no_prior_weights ≈ sort(ref_no_prior_weights, rev = true) atol = 0.0001
 
 println("empirical bayes glue tests passed")
 end


### PR DESCRIPTION
Added ability to call `empirical_bayes` without a `priors` argument to get posteriors under null prior values. 