### PR TITLE
Ensure positive PUC scores

### DIFF
--- a/src/network_inference.jl
+++ b/src/network_inference.jl
@@ -88,7 +88,7 @@ function get_puc_scores(nodes, number_of_nodes, estimator, base)
 
     function increment_puc_scores(x, z, mi, redundancy, puc_scores)
         puc_score = (mi - redundancy) / mi
-        puc_score = isfinite(puc_score) ? puc_score : zero(puc_score)
+        puc_score = isfinite(puc_score) && puc_score >= 0 ? puc_score : zero(puc_score)
         puc_scores[x, z] += puc_score
         puc_scores[z, x] += puc_score
     end


### PR DESCRIPTION
Rounding errors in unique information calculation can result in negative PUC scores, that then cause gamma fit to fail during context step.  Add check to ensure positive PUC scores.